### PR TITLE
Regularize sigla

### DIFF
--- a/src/main/scala/net/collatex/reptilian/AlignmentRibbon.scala
+++ b/src/main/scala/net/collatex/reptilian/AlignmentRibbon.scala
@@ -7,6 +7,7 @@ import scala.collection.mutable
 import scala.collection.mutable.ListBuffer
 import scala.language.postfixOps
 import scala.math.Ordering
+import math.Ordered.orderingToOrdered
 
 opaque type Siglum = String
 object Siglum:
@@ -18,14 +19,14 @@ object Siglum:
     (a: Siglum, b: Siglum) => a.value.compare(b.value)
 given CanEqual[Siglum, Siglum] = CanEqual.derived
 
-type WitnessReadings = Map[Siglum, TokenRange] // type alias
+type WitnessReadings = Map[WitId, TokenRange] // type alias
 
 sealed trait AlignmentUnit // supertype AlignmentRibbon (with children) and AlignmentPoint (with groups)
 
 /** Zone to be processed in phase two
- *
- * Same input as AlignmentPoint (varargs of (Siglum, TokenRange)) but create only WitnessReadings and no WitnessGroups
- */
+  *
+  * Same input as AlignmentPoint (varargs of (Siglum, TokenRange)) but create only WitnessReadings and no WitnessGroups
+  */
 final case class UnalignedZone(witnessReadings: WitnessReadings, global: Boolean) extends AlignmentUnit:
   def convertToTokenLists(): List[List[Token]] =
     val sortedKeys = this.witnessReadings.keys.toSeq.sorted
@@ -34,27 +35,27 @@ final case class UnalignedZone(witnessReadings: WitnessReadings, global: Boolean
   def splitUnalignedZone(
       alignment_point_for_split: AlignmentPoint,
       global: Boolean
-    ): (UnalignedZone, UnalignedZone) =
+  ): (UnalignedZone, UnalignedZone) =
 
     // We filter out all the witnesses that have an empty range after the split
     val preAndPost = this.witnessReadings
       .map((k, v) => k -> v.splitTokenRange(alignment_point_for_split.witnessReadings(k)))
     val unfilteredPre = preAndPost.map((k, v) => k -> v._1)
     val unfilteredPost = preAndPost.map((k, v) => k -> v._2)
-    val pre  = removeEmptyTokenRanges(unfilteredPre)
+    val pre = removeEmptyTokenRanges(unfilteredPre)
     val post = removeEmptyTokenRanges(unfilteredPost)
     (UnalignedZone(pre, global), UnalignedZone(post, global))
 
-  private def removeEmptyTokenRanges(before: Map[Siglum, TokenRange]): Map[Siglum, TokenRange] =
+  private def removeEmptyTokenRanges(before: Map[WitId, TokenRange]): Map[WitId, TokenRange] =
     before.filter((_, v) => v.isInstanceOf[LegalTokenRange])
 
   def createLocalTokenArrayForUnalignedZone: Vector[TokenEnum] =
     // Create a local token array by filtering the global one
-    // Selection comes in unsorted, so sort by siglum first
+    // Selection comes in unsorted, so sort by witId first
     val localTokenArrayByWitness: Seq[Vector[TokenEnum]] = {
       val orderedWitnessReadings =
         for siglum <- this.witnessReadings.keys.toSeq.sorted
-          yield this.witnessReadings(siglum)
+        yield this.witnessReadings(siglum)
       for r <- orderedWitnessReadings yield r.tokens
     }
     // Replacement that uses witnessGroups instead of witnessReadings
@@ -67,16 +68,15 @@ final case class UnalignedZone(witnessReadings: WitnessReadings, global: Boolean
         )
     lTa
 
-
 final case class AlignmentPoint(witnessReadings: WitnessReadings, witnessGroups: Set[WitnessReadings])
-  extends AlignmentUnit
+    extends AlignmentUnit
 
 /** Custom constructor to simplify creation of AlignmentPoint
- *
- * Input is a varargs of (Siglum, TokenRange). Will eventually create only WitnessGroups and no WitnessReadings
- */
+  *
+  * Input is a varargs of (Siglum, TokenRange). Will eventually create only WitnessGroups and no WitnessReadings
+  */
 object AlignmentPoint {
-  def apply(gTa: Vector[TokenEnum], m: (Siglum, TokenRange)*): AlignmentPoint =
+  def apply(gTa: Vector[TokenEnum], m: (WitId, TokenRange)*): AlignmentPoint =
     val wr = m.toMap
     val wg = wr
       .groupBy((_, offsets) =>
@@ -101,7 +101,6 @@ object AlignmentPoint {
 
 }
 
-
 /** AlignmentRibbon
   *
   * Container for all alignment units
@@ -112,4 +111,3 @@ object AlignmentPoint {
 final case class AlignmentRibbon(
     children: ListBuffer[AlignmentUnit] = ListBuffer.empty
 ) extends AlignmentUnit
-

--- a/src/main/scala/net/collatex/reptilian/createAlignmentRibbon.scala
+++ b/src/main/scala/net/collatex/reptilian/createAlignmentRibbon.scala
@@ -16,15 +16,16 @@ import upickle.default.write
 // Basically an inverse of the current control flow.
 
 def createAlignmentRibbon(
-    sigla: List[Siglum],
+    gTaSigla: List[WitId],
+    displaySigla: List[Siglum],
     gTa: Vector[TokenEnum]
 ): AlignmentRibbon =
-  val globalUnalignedZone: UnalignedZone = createGlobalUnalignedZone(sigla, gTa)
+  val globalUnalignedZone: UnalignedZone = createGlobalUnalignedZone(gTaSigla, gTa)
   // align, recursively full depth blocks in this unaligned zone
-  val alignment = ListBuffer().appendAll(alignFullDepthBlocks(globalUnalignedZone, sigla))
+  val alignment = ListBuffer().appendAll(alignFullDepthBlocks(globalUnalignedZone, gTaSigla))
   AlignmentRibbon(alignment)
 
-def alignFullDepthBlocks(unalignedZone: UnalignedZone, sigla: List[Siglum]): List[AlignmentUnit] =
+def alignFullDepthBlocks(unalignedZone: UnalignedZone, gTaSigla: List[WitId]): List[AlignmentUnit] =
   val gTa: Vector[TokenEnum] = unalignedZone.witnessReadings.values.head.ta
   // find the full depth blocks for the alignment
   // Ignore blocks and suffix array (first two return items); return list of sorted ReadingNodes
@@ -36,16 +37,16 @@ def alignFullDepthBlocks(unalignedZone: UnalignedZone, sigla: List[Siglum]): Lis
   val (_, _, longestFullDepthNonRepeatingBlocks) = createAlignedBlocks(lTa, witnessCount)
   if longestFullDepthNonRepeatingBlocks.isEmpty
   then { // align unaligned zones
-     alignByClustering(unalignedZone, gTa)
+    alignByClustering(unalignedZone, gTa)
   } else {
     // There are full depth blocks, align by creating a navigation graph
     val fullDepthAlignmentPoints: List[AlignmentPoint] =
-      getAlignmentPointsByTraversingNavigationGraph(longestFullDepthNonRepeatingBlocks, lTa, gTa, sigla)
+      getAlignmentPointsByTraversingNavigationGraph(longestFullDepthNonRepeatingBlocks, lTa, gTa, gTaSigla)
     val alignment = recursiveBuildAlignment(
       ListBuffer(),
       unalignedZone,
       fullDepthAlignmentPoints,
-      sigla
+      gTaSigla
     )
     alignment
   }
@@ -55,7 +56,7 @@ def recursiveBuildAlignment(
     result: ListBuffer[AlignmentUnit],
     unalignedZone: UnalignedZone,
     remainingAlignment: List[AlignmentPoint],
-    sigla: List[Siglum]
+    sigla: List[WitId]
 ): List[AlignmentUnit] =
 
   // On first run, unalignedZone contains full token ranges (globalUnalignedZone) and
@@ -87,7 +88,7 @@ def getAlignmentPointsByTraversingNavigationGraph(
     longestFullDepthNonRepeatingBlocks: List[FullDepthBlock],
     lTa: Vector[TokenEnum],
     gTa: Vector[TokenEnum],
-    sigla: List[Siglum]
+    sigla: List[WitId]
 ) =
   // blocks come back with lTa; map to gTa
   // create navigation graph and filter out transposed nodes
@@ -114,7 +115,7 @@ def getAlignmentPointsByTraversingNavigationGraph(
   // We need to restore the sorting that we destroyed when we created the set
   // Called repeatedly, so there is always a w0, although not always the same one
   //   (tokens know their global witness membership, so we can recover original witness membership when needed)
-  val siglumForSorting: Siglum = alignmentPoints.head.witnessReadings.keys.head
+  val siglumForSorting: WitId = alignmentPoints.head.witnessReadings.keys.head
   val sortedReadingNodes = alignmentPoints // Sort reading nodes in token order
     .toVector
     .sortBy(_.witnessReadings(siglumForSorting).start)
@@ -127,7 +128,7 @@ def alignByClustering(zone: UnalignedZone, gTa: Vector[TokenEnum]): List[Alignme
   val nodesToCluster: List[ClusterInfo] = clusterWitnesses(darwinReadings)
   // println(s"clusters: $nodesToCluster")
   if nodesToCluster.isEmpty then { // One witness, so construct local ribbon directly
-    val wg: Set[Map[Siglum, TokenRange]] = Set(zone.witnessReadings)
+    val wg: Set[Map[WitId, TokenRange]] = Set(zone.witnessReadings)
     List(AlignmentPoint(zone.witnessReadings, wg))
   } else // Variation node with … er … variation
     // println("Align by clustering")
@@ -141,10 +142,7 @@ def alignByClustering(zone: UnalignedZone, gTa: Vector[TokenEnum]): List[Alignme
           .map(f =>
             f.verticesIterator
               .map(tr =>
-                val witness: Siglum = {
-                  val inSiglum: String = gTa(tr.start).w.toString
-                  Siglum(inSiglum)
-                }
+                val witness: WitId = gTa(tr.start).w
                 witness -> tr
               )
               .toMap
@@ -166,7 +164,7 @@ def alignByClustering(zone: UnalignedZone, gTa: Vector[TokenEnum]): List[Alignme
 def blocksToNodes(
     blocks: Iterable[FullDepthBlock],
     gTa: Vector[TokenEnum],
-    sigla: List[Siglum]
+    sigla: List[WitId]
 ): Iterable[AlignmentPoint] =
   val result = blocks
     // THERE IS LTA AND GTA CONFUSION HERE, MAPPING IS REDUNDANT. IS DONE EARLIER
@@ -177,7 +175,7 @@ def blocksToNodes(
 def fullDepthBlockToAlignmentPoint(
     block: FullDepthBlock,
     lTa: Vector[TokenEnum], // local
-    sigla: List[Siglum]
+    sigla: List[WitId]
 ): AlignmentPoint =
   //  println(s"block: $block")
   val readings = block.instances
@@ -194,17 +192,17 @@ def fullDepthBlockToAlignmentPoint(
   val wg = Set(readings)
   AlignmentPoint(readings, wg)
 
-def createGlobalUnalignedZone(sigla: List[Siglum], gTa: Vector[TokenEnum]) = {
+def createGlobalUnalignedZone(sigla: List[WitId], gTa: Vector[TokenEnum]) = {
   // NB: We are embarrassed by the mutable map (and by other things, such has having to scan token array)
   // Housekeeping; TODO: Think about witness-set metadata
-  val witnessRanges: mutable.Map[Siglum, TokenRange] = mutable.Map.empty
+  val witnessRanges: mutable.Map[WitId, TokenRange] = mutable.Map.empty
   // go over the tokens and assign the lowest and the highest to the map
   // token doesn't know its position in a specific witness, so use indices
   // TODO: Could be simplified if the routine knew the token length of the witnesses
   for (tokenIndex <- gTa.indices)
     val token = gTa(tokenIndex)
     token match
-      case x:Token =>
+      case x: Token =>
         val tuple =
           witnessRanges.getOrElse(sigla(x.w), TokenRange(tokenIndex, tokenIndex, gTa))
         val minimum = tuple.start

--- a/src/main/scala/net/collatex/reptilian/reptilian.scala
+++ b/src/main/scala/net/collatex/reptilian/reptilian.scala
@@ -51,12 +51,11 @@ def readData(pathToData: Path): List[(String, String)] =
     .toList
     .map(e => (e.last, os.read(e)))
 
-
 /** Obtain input via manifest and process
   *
   * @param args
   *   args: location of manifest and optional toggle for debug output
- * @return
+  * @return
   */
 @main def manifest(
     args: String*
@@ -81,10 +80,10 @@ def readData(pathToData: Path): List[(String, String)] =
         previewWitness(data).foreach(System.err.println)
         System.err.println("\nTokens:")
         gTa.foreach(System.err.println)
-      val gTaSigla: List[Siglum] = data.indices.map(e => Siglum(e.toString)).toList // integers
+      val gTaSigla: List[WitId] = data.indices.toList // integers
       val displaySigla: List[Siglum] = data.map(e => Siglum(e.siglum)).toList // user-supplied for rendering
       // Create alignment ribbon
-      val root: AlignmentRibbon = createAlignmentRibbon(gTaSigla, gTa)
+      val root: AlignmentRibbon = createAlignmentRibbon(gTaSigla, displaySigla, gTa)
       // Write to stdout
       val writer = new PrintWriter(Console.out)
       val doctypeHtml: DocType = DocType("html")
@@ -99,7 +98,7 @@ def readData(pathToData: Path): List[(String, String)] =
       writer.flush()
   }
 
-/** Display siglum and initial slice of text of all witnesses
+/** Display witId and initial slice of text of all witnesses
   *
   * Used only for debugging
   *
@@ -335,7 +334,7 @@ def parseManifest(manifestPathString: String): Either[String, Seq[CollateXWitnes
     manifestXml <- retrieveManifestXml(manifestPath)
     manifestRnc = Source.fromResource("manifest.rnc").getLines().mkString("\n")
     _ <- validateRnc(manifestXml, manifestRnc)
-    _ <- validateSchematron(manifestXml, "manifest-sch-compiled.xsl", manifestUri).left.map(_.mkString("\n"))
+//    _ <- validateSchematron(manifestXml, "manifest-sch-compiled.xsl", manifestUri).left.map(_.mkString("\n"))
     witnessData <- retrieveWitnessData(manifestXml, manifestPath)
   } yield witnessData
 

--- a/src/main/scala/net/collatex/reptilian/reptilian.scala
+++ b/src/main/scala/net/collatex/reptilian/reptilian.scala
@@ -334,7 +334,7 @@ def parseManifest(manifestPathString: String): Either[String, Seq[CollateXWitnes
     manifestXml <- retrieveManifestXml(manifestPath)
     manifestRnc = Source.fromResource("manifest.rnc").getLines().mkString("\n")
     _ <- validateRnc(manifestXml, manifestRnc)
-//    _ <- validateSchematron(manifestXml, "manifest-sch-compiled.xsl", manifestUri).left.map(_.mkString("\n"))
+    _ <- validateSchematron(manifestXml, "manifest-sch-compiled.xsl", manifestUri).left.map(_.mkString("\n"))
     witnessData <- retrieveWitnessData(manifestXml, manifestPath)
   } yield witnessData
 

--- a/src/main/scala/net/collatex/reptilian/tokenization.scala
+++ b/src/main/scala/net/collatex/reptilian/tokenization.scala
@@ -24,16 +24,16 @@ import scala.util.matching.Regex
 // Read external JSON into TokenJSON to avoid reading into enum subtype; then remap
 case class TokenJSON(t: String, n: String, w: Int, g: Int) derives ReadWriter
 
-type witId = Int
+type WitId = Int
 
 enum TokenEnum:
-  case Token(t: String, n: String, w: witId, g: Int) extends TokenEnum
-  case TokenSep(t: String, n: String, w: witId, g: Int) extends TokenEnum
-  case TokenSg(t: String, n: String, w: witId, g: Int) extends TokenEnum
-  case TokenHG(t: String, n: String, w: witId, g: Int, he: EdgeLabel, tr: TokenRange) extends TokenEnum
+  case Token(t: String, n: String, w: WitId, g: Int) extends TokenEnum
+  case TokenSep(t: String, n: String, w: WitId, g: Int) extends TokenEnum
+  case TokenSg(t: String, n: String, w: WitId, g: Int) extends TokenEnum
+  case TokenHG(t: String, n: String, w: WitId, g: Int, he: EdgeLabel, tr: TokenRange) extends TokenEnum
   def t: String
   def n: String
-  def w: witId
+  def w: WitId
   def g: Int
 
 /** Normalize witness data
@@ -70,7 +70,7 @@ def processToken(str: String): TokenState[TokenEnum] = State { state =>
   else (state.copy(offset = offset + 1), TokenEnum.Token(str, normalize(str), emptyCount, offset))
 }
 
-def createGTa(tokensPerWitnessLimit: witId, data: Seq[CollateXWitnessData], tokenPattern: Regex) = {
+def createGTa(tokensPerWitnessLimit: WitId, data: Seq[CollateXWitnessData], tokenPattern: Regex) = {
   val tokenizer = makeTokenizer(tokenPattern, tokensPerWitnessLimit)
   val inputTokens: Vector[String] = tokenizer(data)
   val program: TokenState[Vector[TokenEnum]] = inputTokens.traverse(processToken)

--- a/src/test/scala/net/collatex/reptilian/secondAlignmentPhaseTest.scala
+++ b/src/test/scala/net/collatex/reptilian/secondAlignmentPhaseTest.scala
@@ -620,7 +620,7 @@
 //      pathToDarwin
 //    ) // One string per witness
 //    val witnessStrings: List[String] = witnessInputInfo.map(_._2)
-//    val sigla: List[Siglum] = witnessInputInfo.map(_._1).map(Siglum(_))
+//    val gTaSigla: List[Siglum] = witnessInputInfo.map(_._1).map(Siglum(_))
 //    val gTa: Vector[TokenEnum] = tokenize(tokenizer, Int.MaxValue)(witnessStrings) // global token array
 //    val nodesToCluster = clusterWitnesses(mexicoData)
 //    // val expected = ???


### PR DESCRIPTION
This PR seeks to distinguish:

* `gTaSigla`: instances of `WitId`, which is a type alias for `Int`, created as consecutive zero-based integers according to the order of witnesses in the manifest
* `displaySigla`: instances of `Siglum` based on strings supplied by the user in the manifest

`gTaSigla` (`WitId`) is used almost everywhere. `displaySigla` (`Siglum`) is used only for alignment-ribbon visualization.

Question: We regard the Alignment Ribbon as our abstract model, which can then be serialized / visualized in a variety of ways. In this PR the display sigla are passed to the visualization code as a separate parameter. Since the same display sigla will be needed for all visualizations, should they be integrated into the pre-visualization alignment-ribbon model, so that they won't have to be passed separately to each and every visualization? Or is it better to leave them as a separate parameter? In case this is relevant, there will be parameters that are specific to a visualization. For example, the colors, which will eventually be retrieved from the manifest, will not be passed to visualizations that don't use color. This means that some visualizations will require multiple parameters. Do we leave display sigla as a separate parameter because they're a different type of information and because we'll have multiple parameters in any case? Or do we integrate them into the model because they will be part of all visualizations?

Whatever the answer to the preceding question, I'd suggest merging this (assuming it passes review) and regarding further changes in the management of the display sigla as a separate task.